### PR TITLE
Add basic Flutter application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-# siscontRestaurantes
-siscontRestaurantes
+# Siscont Restaurantes
+
+Este repositório contém um aplicativo mobile criado em Flutter para gerenciar restaurantes.
+
+## Estrutura
+- `lib/main.dart`: ponto de entrada do aplicativo.
+- `pubspec.yaml`: definição das dependências do projeto.
+
+## Como executar
+1. Certifique-se de ter o Flutter instalado em sua máquina.
+2. No diretório do projeto, execute `flutter pub get` para baixar as dependências.
+3. Em seguida, rode `flutter run` para iniciar o aplicativo em um emulador ou dispositivo conectado.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Siscont Restaurantes',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const HomePage(),
+    );
+  }
+}
+
+class HomePage extends StatelessWidget {
+  const HomePage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Siscont Restaurantes')),
+      body: const Center(child: Text('Bem-vindo ao Siscont Restaurantes!')),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,17 @@
+name: siscont_restaurantes
+description: Aplicativo mobile em Flutter para gerenciar restaurantes.
+version: 0.1.0
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+
+  cupertino_icons: ^1.0.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- set up initial Flutter app skeleton with `pubspec.yaml`
- add basic `main.dart` with welcome screen
- update README with app instructions

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879443099208326bf099ed1ef90e554