### PR TITLE
Add SQLite connection for offline use

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Siscont Restaurantes
 
 Este repositório contém um aplicativo mobile criado em Flutter para gerenciar restaurantes.
+O aplicativo utiliza um banco de dados SQLite local para funcionar mesmo sem conexão com a internet.
 
 ## Estrutura
 - `lib/main.dart`: ponto de entrada do aplicativo.
@@ -10,3 +11,6 @@ Este repositório contém um aplicativo mobile criado em Flutter para gerenciar 
 1. Certifique-se de ter o Flutter instalado em sua máquina.
 2. No diretório do projeto, execute `flutter pub get` para baixar as dependências.
 3. Em seguida, rode `flutter run` para iniciar o aplicativo em um emulador ou dispositivo conectado.
+
+### Offline
+O uso do pacote `sqflite` permite armazenar dados localmente, garantindo que o aplicativo funcione mesmo sem acesso à internet.

--- a/lib/db/database_helper.dart
+++ b/lib/db/database_helper.dart
@@ -1,0 +1,39 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:path/path.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:sqflite/sqflite.dart';
+
+class DatabaseHelper {
+  static final DatabaseHelper _instance = DatabaseHelper._internal();
+
+  factory DatabaseHelper() => _instance;
+
+  DatabaseHelper._internal();
+
+  static Database? _db;
+
+  Future<Database> get database async {
+    if (_db != null) return _db!;
+    _db = await _initDb();
+    return _db!;
+  }
+
+  Future<Database> _initDb() async {
+    Directory documentsDirectory = await getApplicationDocumentsDirectory();
+    final path = join(documentsDirectory.path, 'siscont.db');
+    return await openDatabase(
+      path,
+      version: 1,
+      onCreate: (Database db, int version) async {
+        await db.execute('''
+          CREATE TABLE sample (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT
+          )
+        ''');
+      },
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,11 @@
 import 'package:flutter/material.dart';
+import 'db/database_helper.dart';
 
-void main() => runApp(const MyApp());
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await DatabaseHelper().database;
+  runApp(const MyApp());
+}
 
 class MyApp extends StatelessWidget {
   const MyApp({Key? key}) : super(key: key);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,9 @@ dependencies:
     sdk: flutter
 
   cupertino_icons: ^1.0.2
+  sqflite: ^2.0.0+4
+  path_provider: ^2.0.11
+  path: ^1.8.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add SQLite dependencies in `pubspec.yaml`
- create `DatabaseHelper` to manage a local database
- initialize the database in `main.dart`
- document offline support in the README

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68794e37d838832691c77d63b50c41f6