### PR TITLE
Add Supabase test button

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,6 @@ O aplicativo utiliza um banco de dados SQLite local para funcionar mesmo sem con
 
 ### Offline
 O uso do pacote `sqflite` permite armazenar dados localmente, garantindo que o aplicativo funcione mesmo sem acesso à internet.
+
+### Teste de conexão com Supabase
+Na tela principal há um botão **Testar Supabase** que busca os registros da tabela `CADE_EMPRESA` no Supabase e exibe a quantidade encontrada.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,14 +22,49 @@ class MyApp extends StatelessWidget {
   }
 }
 
-class HomePage extends StatelessWidget {
+class HomePage extends StatefulWidget {
   const HomePage({Key? key}) : super(key: key);
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  String _result = '';
+
+  Future<void> _fetchEmpresas() async {
+    try {
+      final data =
+          await SupabaseManager().client.from('CADE_EMPRESA').select();
+      setState(() {
+        _result = 'Encontrado: ${data.length} registros';
+      });
+    } catch (e) {
+      setState(() {
+        _result = 'Erro ao conectar ao Supabase';
+      });
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Siscont Restaurantes')),
-      body: const Center(child: Text('Bem-vindo ao Siscont Restaurantes!')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text('Bem-vindo ao Siscont Restaurantes!'),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: _fetchEmpresas,
+              child: const Text('Testar Supabase'),
+            ),
+            const SizedBox(height: 20),
+            Text(_result),
+          ],
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- add Supabase fetch button on main screen
- document the new button in README

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68795046b93083269125f89c19c96aa2