### PR TITLE
Implement automatic sync with Supabase

### DIFF
--- a/lib/db/database_helper.dart
+++ b/lib/db/database_helper.dart
@@ -30,10 +30,30 @@ class DatabaseHelper {
         await db.execute('''
           CREATE TABLE sample (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
-            name TEXT
+            name TEXT,
+            synced INTEGER DEFAULT 0
           )
         ''');
       },
     );
+  }
+
+  Future<int> insertSample(String name) async {
+    final dbClient = await database;
+    return await dbClient.insert('sample', {
+      'name': name,
+      'synced': 0,
+    });
+  }
+
+  Future<List<Map<String, dynamic>>> getPendingSamples() async {
+    final dbClient = await database;
+    return await dbClient.query('sample', where: 'synced = ?', whereArgs: [0]);
+  }
+
+  Future<void> markSampleSynced(int id) async {
+    final dbClient = await database;
+    await dbClient
+        .update('sample', {'synced': 1}, where: 'id = ?', whereArgs: [id]);
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 import 'db/database_helper.dart';
 import 'supabase/supabase_manager.dart';
+import 'sync_manager.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await SupabaseManager().init();
   await DatabaseHelper().database;
+  SyncManager().start();
   runApp(const MyApp());
 }
 
@@ -32,6 +34,14 @@ class HomePage extends StatefulWidget {
 class _HomePageState extends State<HomePage> {
   String _result = '';
 
+  Future<void> _addSample() async {
+    final id =
+        await DatabaseHelper().insertSample('Registro ${DateTime.now()}');
+    setState(() {
+      _result = 'Inserido localmente id $id';
+    });
+  }
+
   Future<void> _fetchEmpresas() async {
     try {
       final data =
@@ -55,6 +65,11 @@ class _HomePageState extends State<HomePage> {
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             const Text('Bem-vindo ao Siscont Restaurantes!'),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: _addSample,
+              child: const Text('Adicionar Registro Local'),
+            ),
             const SizedBox(height: 20),
             ElevatedButton(
               onPressed: _fetchEmpresas,

--- a/lib/sync_manager.dart
+++ b/lib/sync_manager.dart
@@ -1,0 +1,46 @@
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+import 'db/database_helper.dart';
+import 'supabase/supabase_manager.dart';
+
+class SyncManager {
+  static final SyncManager _instance = SyncManager._internal();
+
+  factory SyncManager() => _instance;
+
+  SyncManager._internal();
+
+  StreamSubscription<ConnectivityResult>? _subscription;
+
+  void start() {
+    _subscription ??=
+        Connectivity().onConnectivityChanged.listen((result) {
+      if (result != ConnectivityResult.none) {
+        _syncPendingData();
+      }
+    });
+  }
+
+  Future<void> _syncPendingData() async {
+    final pending = await DatabaseHelper().getPendingSamples();
+    for (final row in pending) {
+      try {
+        await SupabaseManager()
+            .client
+            .from('sample')
+            .insert({'name': row['name']});
+        await DatabaseHelper().markSampleSynced(row['id'] as int);
+      } catch (_) {
+        // If any insert fails, stop processing to retry later
+        break;
+      }
+    }
+  }
+
+  Future<void> dispose() async {
+    await _subscription?.cancel();
+    _subscription = null;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   path_provider: ^2.0.11
   path: ^1.8.2
   supabase_flutter: ^1.10.0
+  connectivity_plus: ^3.0.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `connectivity_plus` package
- extend local database with sync flag and helper methods
- create `SyncManager` to send pending rows when connectivity is available
- hook `SyncManager` into `main.dart`
- add UI button to insert sample local data

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68795807ef1c8326bcb7efe02293c83d