### PR TITLE
Add company configuration screen

### DIFF
--- a/lib/config_page.dart
+++ b/lib/config_page.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'supabase/supabase_manager.dart';
+
+class ConfigPage extends StatefulWidget {
+  const ConfigPage({Key? key}) : super(key: key);
+
+  @override
+  State<ConfigPage> createState() => _ConfigPageState();
+}
+
+class _ConfigPageState extends State<ConfigPage> {
+  final TextEditingController _cnpjController = TextEditingController();
+  String _result = '';
+
+  Future<void> _fetchEmpresa() async {
+    final cnpj = _cnpjController.text.trim();
+    if (cnpj.isEmpty) return;
+    try {
+      final data = await SupabaseManager()
+          .client
+          .from('CADE_EMPRESA')
+          .select()
+          .eq('cemp_cnpj', cnpj)
+          .maybeSingle();
+      setState(() {
+        if (data == null) {
+          _result = 'Empresa não encontrada';
+        } else {
+          _result = 'Empresa: ${data['cemp_nome_fantasia'] ?? 'sem nome'}';
+        }
+      });
+    } catch (_) {
+      setState(() {
+        _result = 'Erro ao buscar empresa';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Configurações')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _cnpjController,
+              decoration: const InputDecoration(labelText: 'CNPJ'),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: _fetchEmpresa,
+              child: const Text('Buscar Empresa'),
+            ),
+            const SizedBox(height: 20),
+            Text(_result),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'db/database_helper.dart';
 import 'supabase/supabase_manager.dart';
 import 'sync_manager.dart';
+import 'config_page.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -74,6 +75,18 @@ class _HomePageState extends State<HomePage> {
             ElevatedButton(
               onPressed: _fetchEmpresas,
               child: const Text('Testar Supabase'),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const ConfigPage(),
+                  ),
+                );
+              },
+              child: const Text('Configurar Empresa'),
             ),
             const SizedBox(height: 20),
             Text(_result),


### PR DESCRIPTION
## Summary
- add `ConfigPage` screen to fetch company data from Supabase by CNPJ
- open ConfigPage from the main screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68796c62aa0083268311d2fca66909b3